### PR TITLE
fix: Increment `stack_size` when compiling `putobject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ You could write:
 in :putobject
   operand = iseq.body.iseq_encoded[insn_index + 1]
   asm.mov(STACK[stack_size], operand)
+  stack_size += 1
 ```
 
 </details>


### PR DESCRIPTION
This is probably implied, but when I first wrote the code from the tutorial, it didn't seem to work for me. Only later did I realize I had to increment the stack size. So maybe this just makes it tiny bit more beginner friendly?