### PR TITLE
Fix sample of set receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ in :opt_send_without_block
   asm.sub(:rax, C.VALUE.size)
   asm.mov([CFP, C.rb_control_frame_t.offsetof(:ep)], :rax)
   # Set receiver
-  asm.sub(:rax, STACK[stack_size - C.vm_ci_argc(cd.ci) - 1])
+  asm.mov(:rax, STACK[stack_size - C.vm_ci_argc(cd.ci) - 1])
   asm.mov([CFP, C.rb_control_frame_t.offsetof(:self)], :rax)
 
   # Save stack registers


### PR DESCRIPTION
Because the receiver is stacked on the stack,
I wonder if it need to `mov` instead of `sub` the `rax` when setting the receiver before calling the method?
As stated in the hint, the receiver is not used, so it will work without this modification.